### PR TITLE
Add support for dose specific cli args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ repository.
 Development
 -----------
 
+* Add support for CLI options using the Click_ library for
+  parsing.
+
 * Fix the egg long description to have a distinct path for GitHub
   links and GitHub images, based on the relative URLs of the project
   files. That's a reStructuredText generated from the Dose
@@ -421,3 +424,4 @@ alpha-2012.10.02
 .. _104: https://github.com/gorakhargosh/watchdog/issues/104
 .. _157: https://github.com/gorakhargosh/watchdog/issues/157
 .. _watchdog: https://pypi.python.org/pypi/watchdog
+.. _Click: https://pypi.python.org/pypi/click

--- a/dose/__main__.py
+++ b/dose/__main__.py
@@ -1,5 +1,5 @@
 """Dose GUI for TDD: main script / entry point."""
-import sys, colorama
+import colorama, click
 from dose._legacy import DoseMainWindow
 from dose.misc import ucamel_method
 from dose.compat import wx, quote
@@ -28,15 +28,19 @@ def main_wx(test_command=None):
     app.MainLoop()
 
 
-def main(*args):
-    if not args:
-        if len(sys.argv) > 2:
-            args = map(quote, sys.argv[1:])
-        else:
-            args = sys.argv[1:]
+@click.command(context_settings={
+    "allow_interspersed_args": False
+})
+@click.argument('test', nargs=-1, required=False, type=click.UNPROCESSED)
+def main(test):
+    """
+    TEST: test command with options/arguments
+    """
     colorama.init() # Replaces sys.stdout / sys.stderr to
                     # accept ANSI escape codes on Windows
-    main_wx(test_command=" ".join(args))
+    if len(test) > 1:
+        test = map(quote, test)
+    main_wx(test_command=" ".join(test))
 
 
 if __name__ == "__main__": # Not a "from dose import __main__"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ metadata = {
   "packages": setuptools.find_packages(),
   "install_requires": ["watchdog>=0.6.0",
                        "colorama>=0.3.7",
-                       "docutils>=0.12"], # Needs wxPython as well
+                       "docutils>=0.12",
+                       "click>=6.6"], # Needs wxPython as well
   "entry_points": {"console_scripts": ["dose = dose.__main__:main"]},
   "data_files": [("share/dose/v" + dose.__version__, SHARED_FILES)],
 }


### PR DESCRIPTION
Partial work for #6. Currently we have basic infrastructure for cli args parsing, and support for "--help" and "-h" switches.
