### PR TITLE
Fix a bug related to fcntl.ioctl in PyCharm/Linux

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ repository.
 Development
 -----------
 
+* Fix a problem related to ioctl when running from within PyCharm in
+  Linux.
+
 * Fix the egg long description to have a distinct path for GitHub
   links and GitHub images, based on the relative URLs of the project
   files. That's a reStructuredText generated from the Dose


### PR DESCRIPTION
When running Dose inside PyCharm in a Linux environment, fnctl.ioctl can't determine the window size (see the method TerminalSize#from_io_control in terminal.py). As a result of this, the application will crash even that retrieving this size isn't required at all. In order to allow Dose to run in this environment, this fix catches the exact OSError raised internally by the affected commands and silently ignore them with a brief warning message.

Note: if you happen to know a better solution to this, please feel free to direct me into another trail. In my tests this is only affecting when running from PyCharm, as intended. The problem only arose when I setup my ArchLinux environment (in Windows, even using PyCharm, I haven't yet experienced this problem).